### PR TITLE
Removed outputs to stdout

### DIFF
--- a/src/main/java/co/rsk/altbn128/cloudflare/JniBn128.java
+++ b/src/main/java/co/rsk/altbn128/cloudflare/JniBn128.java
@@ -1,6 +1,9 @@
 package co.rsk.altbn128.cloudflare;
 
 public class JniBn128 {
+
+    private static final Throwable loadError; // null, if library has been loaded successfully, otherwise - holds error details
+
     public native int add(byte[] input, int len, byte[] output);
 
     public native int mul(byte[] input, int len, byte[] output);
@@ -8,12 +11,17 @@ public class JniBn128 {
     public native int pairing(byte[] input, int len, byte[] output);
 
     static {
+        Throwable error = null;
         try {
-            if (NativeLoader.load()) {
-                System.out.println("Successfully loaded.");
-            }
+            NativeLoader.load();
         } catch (Exception e) {
             e.printStackTrace();
+            error = e;
         }
+        loadError = error;
+    }
+
+    public static Throwable getLoadError() {
+        return loadError;
     }
 }


### PR DESCRIPTION
This change removes a message of missing secp256k1 native lib in the `Secp256k1Context` class that's being thrown to console stdout every time the library is loading (in non-linux envs). Also refactored the similar outputs in `JniBn128` class.