### PR TITLE
Removed jcenter() dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
 
 group 'co.rsk'
-version '1.3.0'
+version '1.4.0-SNAPSHOT'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
`JCenter` is now read-only and is about to be shut down at some point. Replaced it with `MavenCentral`